### PR TITLE
Update service keywords in site metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
   keywords: [
     "Beauty Salon",
     " Hair Salon",
-    "Hairdresser",
+    "Hair Coloring",
   ],
   openGraph: {
     title: "BEST Dominican Beauty Salon in Stone Mountain GA | Consentida's by Triny",


### PR DESCRIPTION
- Updated the primary service keyword from "Hairdresser" to "Hair Coloring" in site metadata to more accurately represent current service offerings.

[v0 Session](https://v0.app/chat/cE5tvGHU845)