### PR TITLE
Update SEO keyword from Hair Coloring to Hairdresser

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
   keywords: [
     "Beauty Salon",
     " Hair Salon",
-    "Hair Coloring",
+    "Hairdresser",
   ],
   openGraph: {
     title: "BEST Dominican Beauty Salon in Stone Mountain GA | Consentida's by Triny",


### PR DESCRIPTION
- Updated the primary SEO keyword from "Hair Coloring" to "Hairdresser" in the site metadata to improve search visibility and relevance.

[v0 Session](https://v0.app/chat/cE5tvGHU845)